### PR TITLE
feat(api): add create_plan endpoint and schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
       if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+    rev: v3.0.0
+    hooks:
+      - id: complexipy
+        args: ["--ignore-complexity"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,3 @@ repos:
     rev: v3.0.0
     hooks:
       - id: complexipy
-        args: ["--ignore-complexity"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,3 +402,8 @@ The `make test-auth` command tests:
 - Token refresh functionality
 
 This ensures that after refactoring (especially type imports/exports), all real API integrations still work correctly.
+
+## Development Memories
+
+### Import Guidelines
+- Always add imports at the top module level

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,12 @@ testpaths = ["tests"]
 packages = ["src"]
 
 [dependency-groups]
-dev = ["pre-commit>=4.2.0"]
+dev = [
+  "pre-commit>=4.2.0",
+  "pytest-asyncio>=1.0.0",
+  "pytest-httpx>=0.35.0",
+  "pytest-watcher>=0.4.3",
+]
 
 [tool.ruff]
 target-version = "py313"
@@ -47,15 +52,17 @@ select = [
   "B",  # flake8-bugbear
   "S",  # flake8-bandit (security)
   "UP", # pyupgrade
+  "PL", # pylint
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-  "S101", # assert-used (allow assert in tests)
-  "S105", # hardcoded-password-string (allow in test fixtures)
-  "S106", # hardcoded-password-func-arg (allow in test fixtures)
-  "S108", # hardcoded-temp-file (allow in tests)
-  "S110", # try-except-pass (allow in test cleanup)
+  "S101",    # assert-used (allow assert in tests)
+  "S105",    # hardcoded-password-string (allow in test fixtures)
+  "S106",    # hardcoded-password-func-arg (allow in test fixtures)
+  "S108",    # hardcoded-temp-file (allow in tests)
+  "S110",    # try-except-pass (allow in test cleanup)
+  "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
 ]
 "test_auth.py" = [
   "S110", # try-except-pass (allow in auth error handling)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ packages = ["src"]
 
 [dependency-groups]
 dev = [
+  "complexipy>=3.2.0",
   "pre-commit>=4.2.0",
   "pytest-asyncio>=1.0.0",
   "pytest-httpx>=0.35.0",

--- a/src/auth.py
+++ b/src/auth.py
@@ -20,7 +20,7 @@ import httpx
 from aiohttp import web
 from dotenv import load_dotenv
 
-from .token_store import TokenData, TokenStore
+from src.token_store import TokenData, TokenStore
 
 # Load environment variables
 load_dotenv()

--- a/src/schemas/create_plan.json
+++ b/src/schemas/create_plan.json
@@ -1,0 +1,101 @@
+{
+  "type": "object",
+  "properties": {
+    "plan": {
+      "type": "object",
+      "description": "Complete workout plan structure",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the workout plan"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the workout"
+        },
+        "intervals": {
+          "type": "array",
+          "description": "List of workout intervals",
+          "items": {
+            "type": "object",
+            "properties": {
+              "duration": {
+                "type": "integer",
+                "description": "Duration in seconds"
+              },
+              "targets": {
+                "type": "array",
+                "description": "List of targets for this interval",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "target_type": {
+                      "type": "string",
+                      "description": "Type of target: power, heart_rate, speed, pace, rpe, cadence, ftp, watts, hr, rpm"
+                    },
+                    "target_value": {
+                      "type": "number",
+                      "description": "Target value"
+                    },
+                    "target_min": {
+                      "type": "number",
+                      "description": "Minimum target value for ranges"
+                    },
+                    "target_max": {
+                      "type": "number",
+                      "description": "Maximum target value for ranges"
+                    },
+                    "unit": {
+                      "type": "string",
+                      "description": "Unit of measurement"
+                    }
+                  },
+                  "required": [
+                    "target_type"
+                  ]
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "Name/description of the interval"
+              },
+              "interval_type": {
+                "type": "string",
+                "description": "Type of interval: work, rest, warmup, cooldown, tempo, threshold, recovery, active, or any Wahoo intensity type (wu, cd, lt, map, ac, nm, ftp, recover)"
+              }
+            },
+            "required": [
+              "duration",
+              "targets"
+            ]
+          }
+        },
+        "workout_type": {
+          "type": "string",
+          "description": "Type of workout: bike, run, swim"
+        }
+      },
+      "required": [
+        "name",
+        "intervals"
+      ]
+    },
+    "filename": {
+      "type": "string",
+      "description": "Name of the plan file"
+    },
+    "external_id": {
+      "type": "string",
+      "description": "Unique external ID for the plan"
+    },
+    "provider_updated_at": {
+      "type": "string",
+      "description": "External date/time the file was updated (ISO 8601 format)"
+    }
+  },
+  "required": [
+    "plan",
+    "external_id",
+    "provider_updated_at"
+  ]
+}

--- a/src/schemas/get_plan.json
+++ b/src/schemas/get_plan.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "plan_id": {
+      "type": "integer",
+      "description": "The ID of the plan to retrieve"
+    }
+  },
+  "required": [
+    "plan_id"
+  ]
+}

--- a/src/schemas/get_power_zone.json
+++ b/src/schemas/get_power_zone.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "power_zone_id": {
+      "type": "integer",
+      "description": "The ID of the power zone to retrieve"
+    }
+  },
+  "required": [
+    "power_zone_id"
+  ]
+}

--- a/src/schemas/get_route.json
+++ b/src/schemas/get_route.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "route_id": {
+      "type": "integer",
+      "description": "The ID of the route to retrieve"
+    }
+  },
+  "required": [
+    "route_id"
+  ]
+}

--- a/src/schemas/get_workout.json
+++ b/src/schemas/get_workout.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "workout_id": {
+      "type": "integer",
+      "description": "The ID of the workout to retrieve"
+    }
+  },
+  "required": [
+    "workout_id"
+  ]
+}

--- a/src/schemas/list_plans.json
+++ b/src/schemas/list_plans.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "external_id": {
+      "type": "string",
+      "description": "Filter plans by external ID"
+    }
+  }
+}

--- a/src/schemas/list_power_zones.json
+++ b/src/schemas/list_power_zones.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "properties": {}
+}

--- a/src/schemas/list_routes.json
+++ b/src/schemas/list_routes.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "external_id": {
+      "type": "string",
+      "description": "Filter routes by external ID"
+    }
+  }
+}

--- a/src/schemas/list_workouts.json
+++ b/src/schemas/list_workouts.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "page": {
+      "type": "integer",
+      "description": "Page number (default: 1)",
+      "default": 1
+    },
+    "per_page": {
+      "type": "integer",
+      "description": "Number of items per page (default: 30)",
+      "default": 30
+    },
+    "start_date": {
+      "type": "string",
+      "description": "Filter workouts created after this date (ISO 8601 format)"
+    },
+    "end_date": {
+      "type": "string",
+      "description": "Filter workouts created before this date (ISO 8601 format)"
+    }
+  }
+}

--- a/test_auth.py
+++ b/test_auth.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 import sys
 import time
+from http import HTTPStatus
 
 import httpx
 from dotenv import load_dotenv
@@ -18,19 +19,23 @@ load_dotenv()
 CLIENT_ID = os.getenv("WAHOO_CLIENT_ID")
 
 
-async def test_refresh_token(token_data: TokenData, token_store: TokenStore) -> bool:
-    """Test the refresh token functionality"""
-
+def _validate_client_id() -> bool:
+    """Validate that CLIENT_ID is available."""
     if not CLIENT_ID:
         print("❌ Error: WAHOO_CLIENT_ID not found in environment")
         return False
+    return True
 
+
+def _print_token_info(token_data: TokenData) -> None:
+    """Print token information for debugging."""
     print(f"   Client ID: {CLIENT_ID}")
     print(f"   Refresh token: {token_data.refresh_token[:10]}...")
     print(f"   Code verifier: {token_data.code_verifier[:10]}...")
 
-    # Prepare refresh request
-    # PKCE flow for public clients requires the code_verifier
+
+def _prepare_refresh_data(token_data: TokenData) -> dict:
+    """Prepare refresh request data with client credentials."""
     refresh_data = {
         "client_id": CLIENT_ID,
         "grant_type": "refresh_token",
@@ -51,7 +56,11 @@ async def test_refresh_token(token_data: TokenData, token_store: TokenStore) -> 
     else:
         print("   ⚠️  Warning: No client_secret or code_verifier available")
 
-    # Log the request for debugging
+    return refresh_data
+
+
+def _log_request_data(refresh_data: dict, token_data: TokenData) -> None:
+    """Log the request data for debugging."""
     print("\n   Request data:")
     print(f"   - client_id: {CLIENT_ID}")
     print("   - grant_type: refresh_token")
@@ -60,6 +69,60 @@ async def test_refresh_token(token_data: TokenData, token_store: TokenStore) -> 
         print(f"   - code_verifier: {refresh_data['code_verifier'][:20]}...")
     if "client_secret" in refresh_data:
         print("   - client_secret: [REDACTED]")
+
+
+async def _test_new_token(client, new_token_data: TokenData) -> bool:
+    """Test the new access token by making an API call."""
+    print("\n   Testing new access token...")
+    test_url = "https://api.wahooligan.com/v1/workouts"
+    test_headers = {
+        "Authorization": f"Bearer {new_token_data.access_token}",
+        "Content-Type": "application/json",
+    }
+    test_params = {"page": 1, "per_page": 1}
+
+    test_response = await client.get(test_url, headers=test_headers, params=test_params)
+
+    if test_response.status_code == HTTPStatus.OK:
+        print("   ✅ New token is valid!")
+        return True
+    else:
+        print(f"   ❌ New token test failed: {test_response.status_code}")
+        return False
+
+
+def _handle_refresh_error(response) -> None:
+    """Handle and log refresh token errors."""
+    print(f"   ❌ Refresh failed: {response.status_code}")
+    print(f"   Response: {response.text}")
+
+    # Try to parse error response
+    try:
+        error_data = response.json()
+        if "error_description" in error_data:
+            print(f"\n   Error details: {error_data['error_description']}")
+
+        # Check if this is a client authentication issue
+        if error_data.get("error") == "invalid_client":
+            print("\n   💡 Possible solutions:")
+            print("   1. Ensure WAHOO_CLIENT_ID is correct")
+            print(
+                "   2. Your app might require a client_secret (set WAHOO_CLIENT_SECRET)"
+            )
+            print("   3. The refresh token or code_verifier might be invalid")
+            print("   4. Re-authenticate with 'make auth' to get fresh tokens")
+    except Exception:
+        pass
+
+
+async def test_refresh_token(token_data: TokenData, token_store: TokenStore) -> bool:
+    """Test the refresh token functionality"""
+    if not _validate_client_id():
+        return False
+
+    _print_token_info(token_data)
+    refresh_data = _prepare_refresh_data(token_data)
+    _log_request_data(refresh_data, token_data)
 
     async with httpx.AsyncClient() as client:
         try:
@@ -71,7 +134,7 @@ async def test_refresh_token(token_data: TokenData, token_store: TokenStore) -> 
                 headers=headers,
             )
 
-            if response.status_code == 200:
+            if response.status_code == HTTPStatus.OK:
                 refresh_response = response.json()
                 print("   ✅ Refresh successful!")
 
@@ -83,53 +146,9 @@ async def test_refresh_token(token_data: TokenData, token_store: TokenStore) -> 
                     expires_in = int(new_token_data.expires_at - time.time())
                     print(f"   Expires in: {expires_in} seconds")
 
-                # Test the new token
-                print("\n   Testing new access token...")
-                test_url = "https://api.wahooligan.com/v1/workouts"
-                test_headers = {
-                    "Authorization": f"Bearer {new_token_data.access_token}",
-                    "Content-Type": "application/json",
-                }
-                test_params = {"page": 1, "per_page": 1}
-
-                test_response = await client.get(
-                    test_url, headers=test_headers, params=test_params
-                )
-
-                if test_response.status_code == 200:
-                    print("   ✅ New token is valid!")
-                    return True
-                else:
-                    print(f"   ❌ New token test failed: {test_response.status_code}")
-                    return False
-
+                return await _test_new_token(client, new_token_data)
             else:
-                print(f"   ❌ Refresh failed: {response.status_code}")
-                print(f"   Response: {response.text}")
-
-                # Try to parse error response
-                try:
-                    error_data = response.json()
-                    if "error_description" in error_data:
-                        print(f"\n   Error details: {error_data['error_description']}")
-
-                    # Check if this is a client authentication issue
-                    if error_data.get("error") == "invalid_client":
-                        print("\n   💡 Possible solutions:")
-                        print("   1. Ensure WAHOO_CLIENT_ID is correct")
-                        print(
-                            "   2. Your app might require a client_secret "
-                            "(set WAHOO_CLIENT_SECRET)"
-                        )
-                        print(
-                            "   3. The refresh token or code_verifier might be invalid"
-                        )
-                        print(
-                            "   4. Re-authenticate with 'make auth' to get fresh tokens"
-                        )
-                except Exception:
-                    pass
-
+                _handle_refresh_error(response)
                 return False
 
         except Exception as e:
@@ -137,32 +156,41 @@ async def test_refresh_token(token_data: TokenData, token_store: TokenStore) -> 
             return False
 
 
-async def test_wahoo_credentials():
-    """Test if Wahoo credentials are valid using the WahooAPIClient"""
-
-    # Get token file path
+def _validate_token_file() -> tuple[str | None, str | None]:
+    """Validate token file exists and return path and error message."""
     token_file = os.getenv("WAHOO_TOKEN_FILE")
     if not token_file:
-        print("❌ Error: WAHOO_TOKEN_FILE environment variable is required")
-        print(
+        error_msg = (
+            "❌ Error: WAHOO_TOKEN_FILE environment variable is required\n"
             "Set it to the path where tokens should be stored "
             "(e.g., export WAHOO_TOKEN_FILE=token.json)"
         )
-        return False
+        return None, error_msg
+    return token_file, None
 
-    # Try to load token from TokenStore
+
+def _load_token_data(
+    token_file: str,
+) -> tuple[TokenData | None, TokenStore | None, str | None]:
+    """Load token data from file and return data, store, and error message."""
     try:
         token_store = TokenStore(token_file)
         token_data = token_store.load()
     except Exception as e:
-        print(f"❌ Error initializing token store: {e}")
-        return False
+        return None, None, f"❌ Error initializing token store: {e}"
 
     if not token_data or not token_data.access_token:
-        print(f"❌ Error: No valid token found in {token_file}")
-        print("Run 'make auth' to obtain an access token")
-        return False
+        error_msg = (
+            f"❌ Error: No valid token found in {token_file}\n"
+            "Run 'make auth' to obtain an access token"
+        )
+        return None, None, error_msg
 
+    return token_data, token_store, None
+
+
+def _print_token_status(token_data: TokenData, token_store: TokenStore) -> None:
+    """Print token status information."""
     print("🔍 Testing Wahoo API credentials...")
     print(f"   Token: {token_data.access_token[:10]}...")
     print(f"   Source: Token file ({token_store.token_file})")
@@ -174,6 +202,71 @@ async def test_wahoo_credentials():
         elif token_data.is_expired():
             print("   ⚠️  Warning: Token will expire soon")
 
+
+async def _test_additional_endpoints(client) -> None:
+    """Test additional API endpoints and print results."""
+    print("\n🔍 Testing additional API endpoints...")
+
+    # Test routes endpoint
+    try:
+        routes = await client.list_routes()
+        print(f"   Routes: ✅ Found {len(routes)} route(s)")
+    except Exception as e:
+        print(f"   Routes: ❌ Failed ({str(e)})")
+
+    # Test plans endpoint
+    try:
+        plans = await client.list_plans()
+        print(f"   Plans: ✅ Found {len(plans)} plan(s)")
+    except Exception as e:
+        print(f"   Plans: ❌ Failed ({str(e)})")
+
+    # Test power zones endpoint
+    try:
+        power_zones = await client.list_power_zones()
+        print(f"   Power Zones: ✅ Found {len(power_zones)} power zone(s)")
+    except Exception as e:
+        print(f"   Power Zones: ❌ Failed ({str(e)})")
+
+
+def _check_refresh_token_availability(token_data: TokenData) -> bool:
+    """Check if refresh token is available and print status."""
+    if token_data.refresh_token and token_data.code_verifier:
+        return True
+    else:
+        print("\n⚠️  No refresh token available to test")
+        if not token_data.refresh_token:
+            print("   Missing: refresh_token")
+        if not token_data.code_verifier:
+            print("   Missing: code_verifier")
+        return False
+
+
+def _handle_api_error(e: Exception) -> None:
+    """Handle and log API errors."""
+    if "401" in str(e) or "Authentication failed" in str(e):
+        print("❌ Invalid credentials: Authentication failed")
+        print("   The access token may be expired or invalid")
+    else:
+        print(f"❌ Error testing credentials: {str(e)}")
+
+
+async def test_wahoo_credentials():
+    """Test if Wahoo credentials are valid using the WahooAPIClient"""
+    # Validate token file
+    token_file, error = _validate_token_file()
+    if error:
+        print(error)
+        return False
+
+    # Load token data
+    token_data, token_store, error = _load_token_data(token_file)
+    if error:
+        print(error)
+        return False
+
+    _print_token_status(token_data, token_store)
+
     # Use WahooAPIClient to test endpoints
     try:
         config = WahooConfig()
@@ -183,49 +276,17 @@ async def test_wahoo_credentials():
             print("✅ Success! Credentials are valid")
             print(f"   Found {len(workouts)} workout(s)")
 
-            # Test the new endpoints
-            print("\n🔍 Testing additional API endpoints...")
-
-            # Test routes endpoint
-            try:
-                routes = await client.list_routes()
-                print(f"   Routes: ✅ Found {len(routes)} route(s)")
-            except Exception as e:
-                print(f"   Routes: ❌ Failed ({str(e)})")
-
-            # Test plans endpoint
-            try:
-                plans = await client.list_plans()
-                print(f"   Plans: ✅ Found {len(plans)} plan(s)")
-            except Exception as e:
-                print(f"   Plans: ❌ Failed ({str(e)})")
-
-            # Test power zones endpoint
-            try:
-                power_zones = await client.list_power_zones()
-                print(f"   Power Zones: ✅ Found {len(power_zones)} power zone(s)")
-            except Exception as e:
-                print(f"   Power Zones: ❌ Failed ({str(e)})")
+            await _test_additional_endpoints(client)
 
             # Test refresh token if available
-            if token_data.refresh_token and token_data.code_verifier:
+            if _check_refresh_token_availability(token_data):
                 print("\n🔄 Testing refresh token...")
                 refresh_success = await test_refresh_token(token_data, token_store)
                 return refresh_success
-            else:
-                print("\n⚠️  No refresh token available to test")
-                if not token_data.refresh_token:
-                    print("   Missing: refresh_token")
-                if not token_data.code_verifier:
-                    print("   Missing: code_verifier")
             return True
 
     except Exception as e:
-        if "401" in str(e) or "Authentication failed" in str(e):
-            print("❌ Invalid credentials: Authentication failed")
-            print("   The access token may be expired or invalid")
-        else:
-            print(f"❌ Error testing credentials: {str(e)}")
+        _handle_api_error(e)
         return False
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+Tests for the OAuth authentication module
+"""
+
+import asyncio
+import base64
+import hashlib
+import os
+import secrets
+import time
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from urllib.parse import urlencode
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+
+from src import auth
+from src.token_store import TokenData
+
+
+class TestAuthModule(AioHTTPTestCase):
+    """Test the auth module functions."""
+
+    async def get_application(self):
+        """Create test application."""
+        # Import auth module functions to test
+
+        app = web.Application()
+        app.router.add_get("/callback", auth.callback_handler)
+        return app
+
+    def setUp(self):
+        """Set up test environment."""
+        super().setUp()
+        # Clear global variables
+
+        auth.access_token = None
+        auth.refresh_token = None
+
+    @unittest_run_loop
+    async def test_callback_handler_success(self):
+        """Test successful OAuth callback handling."""
+        with (
+            patch("src.auth.CLIENT_ID", "test_client_id"),
+            patch("src.auth.CLIENT_SECRET", "test_client_secret"),
+            patch("src.auth.REDIRECT_URI", "http://localhost:8080/callback"),
+            patch("src.auth.code_verifier", "test_verifier"),
+            patch("src.auth.TOKEN_URL", "https://api.wahooligan.com/oauth/token"),
+            patch("src.auth.token_store") as mock_store,
+        ):
+            # Mock the token store
+            mock_store.save = Mock()
+
+            # Mock the HTTP client response
+            mock_response = MagicMock()
+            mock_response.status_code = HTTPStatus.OK
+            mock_response.json.return_value = {
+                "access_token": "test_access_token",
+                "refresh_token": "test_refresh_token",
+                "expires_in": 7200,
+                "token_type": "Bearer",
+                "scope": "user_read workouts_read",
+            }
+
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post.return_value = mock_response
+                mock_client.__aenter__.return_value = mock_client
+                mock_client_class.return_value = mock_client
+
+                # Test successful callback
+                response = await self.client.request(
+                    "GET", "/callback?code=test_auth_code"
+                )
+
+                self.assertEqual(response.status, HTTPStatus.OK)
+                self.assertIn("Authentication Successful", await response.text())
+
+                # Verify token store was called
+                mock_store.save.assert_called_once()
+
+    @unittest_run_loop
+    async def test_callback_handler_oauth_error(self):
+        """Test OAuth error handling in callback."""
+        response = await self.client.request(
+            "GET", "/callback?error=access_denied&error_description=User%20denied"
+        )
+
+        self.assertEqual(response.status, HTTPStatus.BAD_REQUEST)
+        self.assertIn("OAuth Error", await response.text())
+
+    @unittest_run_loop
+    async def test_callback_handler_no_code(self):
+        """Test callback without authorization code."""
+        response = await self.client.request("GET", "/callback")
+
+        self.assertEqual(response.status, HTTPStatus.BAD_REQUEST)
+        self.assertIn("No authorization code received", await response.text())
+
+    @unittest_run_loop
+    async def test_callback_handler_token_exchange_failure(self):
+        """Test token exchange failure."""
+        with (
+            patch("src.auth.CLIENT_ID", "test_client_id"),
+            patch("src.auth.CLIENT_SECRET", "test_client_secret"),
+            patch("src.auth.REDIRECT_URI", "http://localhost:8080/callback"),
+            patch("src.auth.code_verifier", "test_verifier"),
+            patch("src.auth.TOKEN_URL", "https://api.wahooligan.com/oauth/token"),
+        ):
+            # Mock failed HTTP response
+            mock_response = MagicMock()
+            mock_response.status_code = HTTPStatus.BAD_REQUEST
+            mock_response.text = "invalid_grant"
+
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post.return_value = mock_response
+                mock_client.__aenter__.return_value = mock_client
+                mock_client_class.return_value = mock_client
+
+                response = await self.client.request(
+                    "GET", "/callback?code=invalid_code"
+                )
+
+                self.assertEqual(response.status, HTTPStatus.INTERNAL_SERVER_ERROR)
+                self.assertIn("Error exchanging code", await response.text())
+
+    @unittest_run_loop
+    async def test_callback_handler_network_error(self):
+        """Test network error during token exchange."""
+        with (
+            patch("src.auth.CLIENT_ID", "test_client_id"),
+            patch("src.auth.CLIENT_SECRET", "test_client_secret"),
+            patch("src.auth.REDIRECT_URI", "http://localhost:8080/callback"),
+            patch("src.auth.code_verifier", "test_verifier"),
+            patch("src.auth.TOKEN_URL", "https://api.wahooligan.com/oauth/token"),
+        ):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post.side_effect = Exception("Network error")
+                mock_client.__aenter__.return_value = mock_client
+                mock_client_class.return_value = mock_client
+
+                response = await self.client.request("GET", "/callback?code=test_code")
+
+                self.assertEqual(response.status, HTTPStatus.INTERNAL_SERVER_ERROR)
+                self.assertIn("Error: Network error", await response.text())
+
+
+class TestPKCEGeneration:
+    """Test PKCE challenge generation."""
+
+    def test_pkce_code_verifier_format(self):
+        """Test that code verifier has correct format."""
+        # Generate like the auth module does
+        code_verifier = (
+            base64.urlsafe_b64encode(secrets.token_bytes(32))
+            .decode("utf-8")
+            .rstrip("=")
+        )
+
+        # Should be URL-safe base64 without padding
+        assert len(code_verifier) >= 43  # 32 bytes -> 43+ chars
+        assert len(code_verifier) <= 128  # RFC requirement
+        assert "=" not in code_verifier  # No padding
+
+    def test_pkce_code_challenge_generation(self):
+        """Test that code challenge is generated correctly."""
+        code_verifier = "test_verifier_123456789012345678901234567890"
+
+        # Generate challenge like the auth module does
+        code_challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+            .decode("utf-8")
+            .rstrip("=")
+        )
+
+        # Verify it's correct SHA256 hash
+        expected_hash = hashlib.sha256(code_verifier.encode()).digest()
+        expected_challenge = (
+            base64.urlsafe_b64encode(expected_hash).decode("utf-8").rstrip("=")
+        )
+
+        assert code_challenge == expected_challenge
+        assert len(code_challenge) == 43  # SHA256 -> 32 bytes -> 43 chars
+
+
+class TestRedirectUriGeneration:
+    """Test redirect URI generation logic."""
+
+    def test_https_port_443_no_port(self):
+        """Test HTTPS on port 443 doesn't include port."""
+        with patch.dict(
+            os.environ,
+            {
+                "WAHOO_REDIRECT_HOST": "example.com",
+                "WAHOO_REDIRECT_PORT": "443",
+                "WAHOO_REDIRECT_SCHEME": "https",
+            },
+        ):
+            # Simulate the auth module logic
+            host = "example.com"
+            port = 443
+            scheme = "https"
+
+            if port == 443 and scheme == "https":
+                redirect_uri = f"{scheme}://{host}/callback"
+            else:
+                redirect_uri = f"{scheme}://{host}:{port}/callback"
+
+            assert redirect_uri == "https://example.com/callback"
+
+    def test_http_port_80_no_port(self):
+        """Test HTTP on port 80 doesn't include port."""
+        with patch.dict(
+            os.environ,
+            {
+                "WAHOO_REDIRECT_HOST": "localhost",
+                "WAHOO_REDIRECT_PORT": "80",
+                "WAHOO_REDIRECT_SCHEME": "http",
+            },
+        ):
+            # Simulate the auth module logic
+            host = "localhost"
+            port = 80
+            scheme = "http"
+
+            if port == 80 and scheme == "http":
+                redirect_uri = f"{scheme}://{host}/callback"
+            else:
+                redirect_uri = f"{scheme}://{host}:{port}/callback"
+
+            assert redirect_uri == "http://localhost/callback"
+
+    def test_custom_port_includes_port(self):
+        """Test custom ports are included in URI."""
+        with patch.dict(
+            os.environ,
+            {
+                "WAHOO_REDIRECT_HOST": "localhost",
+                "WAHOO_REDIRECT_PORT": "8080",
+                "WAHOO_REDIRECT_SCHEME": "http",
+            },
+        ):
+            # Simulate the auth module logic
+            host = "localhost"
+            port = 8080
+            scheme = "http"
+
+            if port == 443 and scheme == "https":
+                redirect_uri = f"{scheme}://{host}/callback"
+            elif port == 80 and scheme == "http":
+                redirect_uri = f"{scheme}://{host}/callback"
+            else:
+                redirect_uri = f"{scheme}://{host}:{port}/callback"
+
+            assert redirect_uri == "http://localhost:8080/callback"
+
+
+class TestAuthConfiguration:
+    """Test authentication configuration and environment variables."""
+
+    def test_default_configuration(self):
+        """Test default configuration values."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Test defaults match auth module
+            host = os.getenv("WAHOO_AUTH_HOST", "localhost")
+            port = int(os.getenv("WAHOO_AUTH_PORT", "8080"))
+            scheme = os.getenv("WAHOO_REDIRECT_SCHEME", "http")
+
+            assert host == "localhost"
+            assert port == 8080
+            assert scheme == "http"
+
+    def test_custom_configuration(self):
+        """Test custom configuration from environment."""
+        with patch.dict(
+            os.environ,
+            {
+                "WAHOO_AUTH_HOST": "0.0.0.0",  # noqa: S104
+                "WAHOO_AUTH_PORT": "9000",
+                "WAHOO_REDIRECT_SCHEME": "https",
+                "WAHOO_AUTH_URL": "https://custom.example.com/oauth/authorize",
+                "WAHOO_TOKEN_URL": "https://custom.example.com/oauth/token",
+            },
+        ):
+            host = os.getenv("WAHOO_AUTH_HOST", "localhost")
+            port = int(os.getenv("WAHOO_AUTH_PORT", "8080"))
+            scheme = os.getenv("WAHOO_REDIRECT_SCHEME", "http")
+            auth_url = os.getenv(
+                "WAHOO_AUTH_URL", "https://api.wahooligan.com/oauth/authorize"
+            )
+            token_url = os.getenv(
+                "WAHOO_TOKEN_URL", "https://api.wahooligan.com/oauth/token"
+            )
+
+            assert host == "0.0.0.0"  # noqa: S104
+            assert port == 9000
+            assert scheme == "https"
+            assert auth_url == "https://custom.example.com/oauth/authorize"
+            assert token_url == "https://custom.example.com/oauth/token"
+
+
+class TestTokenStorage:
+    """Test token storage integration."""
+
+    def test_token_data_creation(self):
+        """Test TokenData object creation with auth module data."""
+        # Test data similar to what auth module creates
+        access_token = "test_access_token"
+        refresh_token = "test_refresh_token"
+        code_verifier = "test_code_verifier"
+        expires_in = 7200
+
+        token_obj = TokenData(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            code_verifier=code_verifier,
+        )
+        token_obj.expires_at = time.time() + expires_in
+
+        assert token_obj.access_token == access_token
+        assert token_obj.refresh_token == refresh_token
+        assert token_obj.code_verifier == code_verifier
+        assert token_obj.expires_at > time.time()
+
+    def test_token_storage_integration(self, tmp_path):
+        """Test token storage and retrieval."""
+        # Create test token file
+        token_file = tmp_path / "test_tokens.json"
+
+        # Mock TokenStore
+        with patch("src.auth.TokenStore") as mock_store_class:
+            mock_store = Mock()
+            mock_store.token_file = str(token_file)
+            mock_store.save = Mock()
+            mock_store_class.return_value = mock_store
+
+            # Test data
+            token_obj = TokenData(
+                access_token="test_token",
+                refresh_token="test_refresh",
+                code_verifier="test_verifier",
+            )
+
+            # Save token
+            mock_store.save(token_obj)
+
+            # Verify save was called
+            mock_store.save.assert_called_once_with(token_obj)
+
+
+class TestOAuthScopes:
+    """Test OAuth scope configuration."""
+
+    def test_required_scopes(self):
+        """Test that all required scopes are included."""
+        # Scopes from the auth module
+        expected_scopes = [
+            "user_read",
+            "workouts_read",
+            "routes_read",
+            "plans_read",
+            "plans_write",
+            "power_zones_read",
+        ]
+
+        auth_scopes = (
+            "user_read workouts_read routes_read plans_read "
+            "plans_write power_zones_read"
+        )
+
+        for scope in expected_scopes:
+            assert scope in auth_scopes
+
+    def test_scope_string_format(self):
+        """Test scope string is properly formatted."""
+        auth_scopes = (
+            "user_read workouts_read routes_read plans_read "
+            "plans_write power_zones_read"
+        )
+
+        # Should be space-separated
+        scope_list = auth_scopes.split()
+        assert len(scope_list) == 6
+        assert "user_read" in scope_list
+        assert "plans_write" in scope_list
+
+
+@pytest.mark.asyncio
+async def test_server_timeout_simulation():
+    """Test server timeout behavior simulation."""
+    # Simulate the timeout logic from the auth module
+    timeout = 0.1  # Short timeout for testing
+    start_time = asyncio.get_event_loop().time()
+    access_token = None
+
+    # Simulate waiting loop
+    while access_token is None:
+        if asyncio.get_event_loop().time() - start_time > timeout:
+            break
+        await asyncio.sleep(0.01)
+
+    # Should have timed out
+    assert access_token is None
+    assert asyncio.get_event_loop().time() - start_time >= timeout
+
+
+class TestErrorHandling:
+    """Test error handling scenarios."""
+
+    def test_missing_token_file_env(self):
+        """Test handling of missing WAHOO_TOKEN_FILE."""
+        with patch.dict(os.environ, {}, clear=True):
+            token_file = os.getenv("WAHOO_TOKEN_FILE")
+            assert token_file is None
+
+    def test_client_credentials_prompting(self):
+        """Test client credentials prompting logic."""
+        with patch.dict(os.environ, {}, clear=True):
+            # Simulate the auth module logic
+            client_id = os.getenv("WAHOO_CLIENT_ID")
+            client_secret = os.getenv("WAHOO_CLIENT_SECRET")
+
+            assert client_id is None
+            assert client_secret is None
+
+            # In real auth module, these would prompt for input
+            # Here we just verify the environment check works
+
+    def test_client_credentials_from_env(self):
+        """Test client credentials from environment."""
+        with patch.dict(
+            os.environ,
+            {
+                "WAHOO_CLIENT_ID": "test_client_id",
+                "WAHOO_CLIENT_SECRET": "test_client_secret",
+            },
+        ):
+            client_id = os.getenv("WAHOO_CLIENT_ID")
+            client_secret = os.getenv("WAHOO_CLIENT_SECRET")
+
+            assert client_id == "test_client_id"
+            assert client_secret == "test_client_secret"
+
+
+class TestAuthUrlGeneration:
+    """Test OAuth authorization URL generation."""
+
+    def test_auth_url_parameters(self):
+        """Test authorization URL contains required parameters."""
+
+        # Simulate auth module URL generation
+        client_id = "test_client_id"
+        redirect_uri = "http://localhost:8080/callback"
+        code_challenge = "test_challenge"
+
+        auth_params = {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": (
+                "user_read workouts_read routes_read plans_read "
+                "plans_write power_zones_read"
+            ),
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+
+        auth_url = (
+            f"https://api.wahooligan.com/oauth/authorize?{urlencode(auth_params)}"
+        )
+
+        # Verify required parameters are present
+        assert "client_id=test_client_id" in auth_url
+        assert "response_type=code" in auth_url
+        assert "code_challenge_method=S256" in auth_url
+        assert "scope=" in auth_url
+        assert "plans_write" in auth_url

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,12 +1,17 @@
 import json
-import os
-import tempfile
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.server import WahooAPIClient, WahooConfig
+from src.models import (
+    CreatePlanRequest,
+    Workout,
+    WorkoutInterval,
+    WorkoutPlan,
+    WorkoutTarget,
+)
+from src.server import WahooAPIClient, WahooConfig, call_tool, list_tools
 from src.token_store import TokenData, TokenStore
 
 
@@ -16,26 +21,18 @@ def wahoo_config():
 
 
 @pytest.fixture
-def temp_token_file():
+def temp_token_file(tmp_path):
     """Create a temporary token file with test data"""
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-        token_data = {
-            "access_token": "test_token",
-            "refresh_token": "test_refresh_token",
-            "code_verifier": "test_verifier",
-            "expires_at": time.time() + 7200,
-            "token_type": "Bearer",
-        }
-        json.dump(token_data, f)
-        temp_path = f.name
-
-    yield temp_path
-
-    # Cleanup
-    try:
-        os.unlink(temp_path)
-    except Exception:
-        pass
+    token_file = tmp_path / "test_token.json"
+    token_data = {
+        "access_token": "test_token",
+        "refresh_token": "test_refresh_token",
+        "code_verifier": "test_verifier",
+        "expires_at": time.time() + 7200,
+        "token_type": "Bearer",
+    }
+    token_file.write_text(json.dumps(token_data))
+    return str(token_file)
 
 
 @pytest.fixture
@@ -216,209 +213,310 @@ def mock_power_zone_detail():
 class TestWahooAPIClient:
     @pytest.mark.asyncio
     async def test_list_workouts(
-        self, wahoo_config, mock_workouts_response, temp_token_file, monkeypatch
+        self,
+        wahoo_config,
+        mock_workouts_response,
+        temp_token_file,
+        monkeypatch,
+        httpx_mock,
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/workouts?page=1&per_page=30",
+            json=mock_workouts_response,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_workouts_response
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            workouts = await client.list_workouts()
 
-                workouts = await client.list_workouts()
-
-                assert len(workouts) == 2
-                assert workouts[0].name == "Morning Run"
-                assert workouts[0].id == 1
-                assert workouts[0].workout_token == "token_1"
-                assert workouts[1].name == "Evening Ride"
-                assert workouts[1].plan_id == 123
-                mock_get.assert_called_once_with(
-                    "/v1/workouts", params={"page": 1, "per_page": 30}
-                )
+            assert len(workouts) == 2
+            assert workouts[0].name == "Morning Run"
+            assert workouts[0].id == 1
+            assert workouts[0].workout_token == "token_1"
+            assert workouts[1].name == "Evening Ride"
+            assert workouts[1].plan_id == 123
 
     @pytest.mark.asyncio
     async def test_list_workouts_with_filters(
-        self, wahoo_config, mock_workouts_response, temp_token_file, monkeypatch
+        self,
+        wahoo_config,
+        mock_workouts_response,
+        temp_token_file,
+        monkeypatch,
+        httpx_mock,
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response with query parameters
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/workouts?page=2&per_page=50&created_after=2024-01-01&created_before=2024-01-31",
+            json=mock_workouts_response,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_workouts_response
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
-
-                await client.list_workouts(
-                    page=2, per_page=50, start_date="2024-01-01", end_date="2024-01-31"
-                )
-
-                mock_get.assert_called_once_with(
-                    "/v1/workouts",
-                    params={
-                        "page": 2,
-                        "per_page": 50,
-                        "created_after": "2024-01-01",
-                        "created_before": "2024-01-31",
-                    },
-                )
+            await client.list_workouts(
+                page=2, per_page=50, start_date="2024-01-01", end_date="2024-01-31"
+            )
 
     @pytest.mark.asyncio
     async def test_get_workout(
-        self, wahoo_config, mock_workout_detail, temp_token_file, monkeypatch
+        self,
+        wahoo_config,
+        mock_workout_detail,
+        temp_token_file,
+        monkeypatch,
+        httpx_mock,
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/workouts/1",
+            json=mock_workout_detail,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_workout_detail
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            workout = await client.get_workout(1)
 
-                workout = await client.get_workout(1)
-
-                assert workout.id == 1
-                assert workout.name == "Morning Run"
-                assert workout.workout_token == "token_1"
-                assert workout.minutes == 45
-                mock_get.assert_called_once_with("/v1/workouts/1")
+            assert workout.id == 1
+            assert workout.name == "Morning Run"
+            assert workout.workout_token == "token_1"
+            assert workout.minutes == 45
 
     @pytest.mark.asyncio
     async def test_list_routes(
-        self, wahoo_config, mock_routes_response, temp_token_file, monkeypatch
+        self,
+        wahoo_config,
+        mock_routes_response,
+        temp_token_file,
+        monkeypatch,
+        httpx_mock,
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/routes",
+            json=mock_routes_response,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_routes_response
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            routes = await client.list_routes()
 
-                routes = await client.list_routes()
-
-                assert len(routes) == 1
-                assert routes[0].name == "Mountain Loop"
-                assert routes[0].id == 1
-                assert routes[0].distance == 25.5
-                mock_get.assert_called_once_with("/v1/routes", params={})
+            assert len(routes) == 1
+            assert routes[0].name == "Mountain Loop"
+            assert routes[0].id == 1
+            assert routes[0].distance == 25.5
 
     @pytest.mark.asyncio
     async def test_get_route(
-        self, wahoo_config, mock_route_detail, temp_token_file, monkeypatch
+        self, wahoo_config, mock_route_detail, temp_token_file, monkeypatch, httpx_mock
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/routes/1",
+            json=mock_route_detail,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_route_detail
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            route = await client.get_route(1)
 
-                route = await client.get_route(1)
-
-                assert route.id == 1
-                assert route.name == "Mountain Loop"
-                assert route.file.url == "https://example.com/route1.fit"
-                mock_get.assert_called_once_with("/v1/routes/1")
+            assert route.id == 1
+            assert route.name == "Mountain Loop"
+            assert route.file.url == "https://example.com/route1.fit"
 
     @pytest.mark.asyncio
     async def test_list_plans(
-        self, wahoo_config, mock_plans_response, temp_token_file, monkeypatch
+        self,
+        wahoo_config,
+        mock_plans_response,
+        temp_token_file,
+        monkeypatch,
+        httpx_mock,
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/plans",
+            json=mock_plans_response,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_plans_response
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            plans = await client.list_plans()
 
-                plans = await client.list_plans()
-
-                assert len(plans) == 1
-                assert plans[0].name == "Training Plan A"
-                assert plans[0].id == 1
-                assert not plans[0].deleted
-                mock_get.assert_called_once_with("/v1/plans", params={})
+            assert len(plans) == 1
+            assert plans[0].name == "Training Plan A"
+            assert plans[0].id == 1
+            assert not plans[0].deleted
 
     @pytest.mark.asyncio
     async def test_get_plan(
-        self, wahoo_config, mock_plan_detail, temp_token_file, monkeypatch
+        self, wahoo_config, mock_plan_detail, temp_token_file, monkeypatch, httpx_mock
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/plans/1",
+            json=mock_plan_detail,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_plan_detail
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            plan = await client.get_plan(1)
 
-                plan = await client.get_plan(1)
+            assert plan.id == 1
+            assert plan.name == "Training Plan A"
+            assert plan.file.url == "https://example.com/plan1.json"
 
-                assert plan.id == 1
-                assert plan.name == "Training Plan A"
-                assert plan.file.url == "https://example.com/plan1.json"
-                mock_get.assert_called_once_with("/v1/plans/1")
+    @pytest.mark.asyncio
+    async def test_create_plan(
+        self, wahoo_config, temp_token_file, monkeypatch, httpx_mock
+    ):
+        monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock response for plan creation
+        mock_create_response = {
+            "id": 100,
+            "user_id": 1,
+            "name": "New Training Plan",
+            "description": "A new training plan",
+            "file": {"url": "https://example.com/new_plan.json"},
+            "external_id": "EXT123",
+            "provider_updated_at": "2024-01-01T12:00:00Z",
+            "created_at": "2024-01-01T12:00:00Z",
+            "updated_at": "2024-01-01T12:00:00Z",
+        }
+
+        # Mock the POST request to /v1/plans
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.wahooligan.com/v1/plans",
+            json=mock_create_response,
+            status_code=201,
+        )
+
+        # Create test workout targets
+        power_target = WorkoutTarget(
+            target_type="power", target_min=200, target_max=250, unit="watts"
+        )
+
+        # Create test workout interval with generic interval type
+        test_interval = WorkoutInterval(
+            duration=600,  # 10 minutes
+            targets=[power_target],
+            name="Test Interval",
+            interval_type="work",  # This should map to "active"
+        )
+
+        # Create test workout plan
+        test_plan = WorkoutPlan(
+            name="New Training Plan",
+            description="A test training plan",
+            intervals=[test_interval],
+            workout_type="bike",
+            author="Test Author",
+        )
+
+        plan_request = CreatePlanRequest(
+            plan=test_plan,
+            filename="test_plan.json",
+            external_id="EXT123",
+            provider_updated_at="2024-01-01T12:00:00Z",
+        )
+
+        async with WahooAPIClient(wahoo_config) as client:
+            created_plan = await client.create_plan(plan_request)
+
+            assert created_plan.id == 100
+            assert created_plan.name == "New Training Plan"
+            assert created_plan.external_id == "EXT123"
+            assert created_plan.file.url == "https://example.com/new_plan.json"
+
+            # Verify the request was made to the correct endpoint
+            assert len(httpx_mock.get_requests()) == 1
+            request = httpx_mock.get_requests()[0]
+            assert request.method == "POST"
+            assert "/v1/plans" in str(request.url)
 
     @pytest.mark.asyncio
     async def test_list_power_zones(
-        self, wahoo_config, mock_power_zones_response, temp_token_file, monkeypatch
+        self,
+        wahoo_config,
+        mock_power_zones_response,
+        temp_token_file,
+        monkeypatch,
+        httpx_mock,
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/power_zones",
+            json=mock_power_zones_response,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_power_zones_response
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            power_zones = await client.list_power_zones()
 
-                power_zones = await client.list_power_zones()
-
-                assert len(power_zones) == 1
-                assert power_zones[0].ftp == 250
-                assert power_zones[0].id == 1
-                assert power_zones[0].zone_7 == 400
-                mock_get.assert_called_once_with("/v1/power_zones")
+            assert len(power_zones) == 1
+            assert power_zones[0].ftp == 250
+            assert power_zones[0].id == 1
+            assert power_zones[0].zone_7 == 400
 
     @pytest.mark.asyncio
     async def test_get_power_zone(
-        self, wahoo_config, mock_power_zone_detail, temp_token_file, monkeypatch
+        self,
+        wahoo_config,
+        mock_power_zone_detail,
+        temp_token_file,
+        monkeypatch,
+        httpx_mock,
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+
+        # Mock the API response
+        httpx_mock.add_response(
+            method="GET",
+            url="https://api.wahooligan.com/v1/power_zones/1",
+            json=mock_power_zone_detail,
+            status_code=200,
+        )
+
         async with WahooAPIClient(wahoo_config) as client:
-            with patch.object(client.client, "get") as mock_get:
-                mock_response = MagicMock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = mock_power_zone_detail
-                mock_response.raise_for_status.return_value = None
-                mock_get.return_value = mock_response
+            power_zone = await client.get_power_zone(1)
 
-                power_zone = await client.get_power_zone(1)
-
-                assert power_zone.id == 1
-                assert power_zone.ftp == 250
-                assert power_zone.critical_power == 275
-                mock_get.assert_called_once_with("/v1/power_zones/1")
+            assert power_zone.id == 1
+            assert power_zone.ftp == 250
+            assert power_zone.critical_power == 275
 
 
 class TestMCPTools:
     @pytest.mark.asyncio
     async def test_list_tools(self):
         # The list_tools decorator creates a handler, we need to call it directly
-        from src.server import list_tools
-
         tools = await list_tools()
-        assert len(tools) == 8
+        assert len(tools) == 9
 
         tool_names = [tool.name for tool in tools]
         expected_tools = [
@@ -428,6 +526,7 @@ class TestMCPTools:
             "get_route",
             "list_plans",
             "get_plan",
+            "create_plan",
             "list_power_zones",
             "get_power_zone",
         ]
@@ -437,69 +536,57 @@ class TestMCPTools:
 
     @pytest.mark.asyncio
     async def test_call_tool_list_workouts(
-        self, mock_workouts_response, temp_token_file
+        self, mock_workouts_response, temp_token_file, monkeypatch
     ):
-        with patch.dict("os.environ", {"WAHOO_TOKEN_FILE": temp_token_file}):
-            with patch(
-                "src.server.WahooAPIClient.list_workouts", new_callable=AsyncMock
-            ) as mock_list:
-                # Convert mock data to Workout objects
-                from src.models import Workout
-
-                workout_objects = [
-                    Workout(**w) for w in mock_workouts_response["workouts"]
-                ]
-                mock_list.return_value = workout_objects
-
-                from src.server import call_tool
-
-                result = await call_tool("list_workouts", {})
-
-                assert len(result) == 1
-                assert "Found 2 workouts" in result[0].text
-                assert "Morning Run" in result[0].text
-                assert "Evening Ride" in result[0].text
-
-    @pytest.mark.asyncio
-    async def test_call_tool_get_workout(self, mock_workout_detail, temp_token_file):
-        with patch.dict("os.environ", {"WAHOO_TOKEN_FILE": temp_token_file}):
-            with patch(
-                "src.server.WahooAPIClient.get_workout", new_callable=AsyncMock
-            ) as mock_get:
-                # Convert mock data to Workout object
-                from src.models import Workout
-
-                workout_object = Workout(**mock_workout_detail)
-                mock_get.return_value = workout_object
-
-                from src.server import call_tool
-
-                result = await call_tool("get_workout", {"workout_id": 1})
-
-                assert len(result) == 1
-                assert "Workout Details (ID: 1)" in result[0].text
-                assert "Morning Run" in result[0].text
-                assert "45 minutes" in result[0].text
-
-    @pytest.mark.asyncio
-    async def test_call_tool_no_token(self):
-        with patch.dict("os.environ", {}, clear=True):
-            from src.server import call_tool
+        monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+        with patch(
+            "src.server.WahooAPIClient.list_workouts", new_callable=AsyncMock
+        ) as mock_list:
+            # Convert mock data to Workout objects
+            workout_objects = [Workout(**w) for w in mock_workouts_response["workouts"]]
+            mock_list.return_value = workout_objects
 
             result = await call_tool("list_workouts", {})
 
             assert len(result) == 1
-            assert "WAHOO_TOKEN_FILE environment variable is required" in result[0].text
+            assert "Found 2 workouts" in result[0].text
+            assert "Morning Run" in result[0].text
+            assert "Evening Ride" in result[0].text
 
     @pytest.mark.asyncio
-    async def test_call_tool_unknown_tool(self, temp_token_file):
-        with patch.dict("os.environ", {"WAHOO_TOKEN_FILE": temp_token_file}):
-            from src.server import call_tool
+    async def test_call_tool_get_workout(
+        self, mock_workout_detail, temp_token_file, monkeypatch
+    ):
+        monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+        with patch(
+            "src.server.WahooAPIClient.get_workout", new_callable=AsyncMock
+        ) as mock_get:
+            # Convert mock data to Workout object
+            workout_object = Workout(**mock_workout_detail)
+            mock_get.return_value = workout_object
 
-            result = await call_tool("unknown_tool", {})
+            result = await call_tool("get_workout", {"workout_id": 1})
 
             assert len(result) == 1
-            assert "Unknown tool: unknown_tool" in result[0].text
+            assert "Workout Details (ID: 1)" in result[0].text
+            assert "Morning Run" in result[0].text
+            assert "45 minutes" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_call_tool_no_token(self, monkeypatch):
+        monkeypatch.delenv("WAHOO_TOKEN_FILE", raising=False)
+        result = await call_tool("list_workouts", {})
+
+        assert len(result) == 1
+        assert "WAHOO_TOKEN_FILE environment variable is required" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_call_tool_unknown_tool(self, temp_token_file, monkeypatch):
+        monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
+        result = await call_tool("unknown_tool", {})
+
+        assert len(result) == 1
+        assert "Unknown tool: unknown_tool" in result[0].text
 
 
 class TestRefreshToken:
@@ -594,84 +681,230 @@ class TestRefreshToken:
         self, wahoo_config, temp_token_file, monkeypatch
     ):
         monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_token_file)
-        with patch.dict(
-            "os.environ",
-            {"WAHOO_CLIENT_ID": "test_client_id", "WAHOO_TOKEN_FILE": temp_token_file},
-        ):
-            async with WahooAPIClient(wahoo_config) as client:
-                with patch("httpx.AsyncClient") as mock_client_class:
-                    mock_response = MagicMock()
-                    mock_response.status_code = 200
-                    mock_response.json.return_value = {
-                        "access_token": "new_access_token",
-                        "refresh_token": "new_refresh_token",
-                        "expires_in": 7200,
-                    }
+        monkeypatch.setenv("WAHOO_CLIENT_ID", "test_client_id")
+        async with WahooAPIClient(wahoo_config) as client:
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_response = MagicMock()
+                mock_response.status_code = 200
+                mock_response.json.return_value = {
+                    "access_token": "new_access_token",
+                    "refresh_token": "new_refresh_token",
+                    "expires_in": 7200,
+                }
 
-                    mock_client = AsyncMock()
-                    mock_client.post.return_value = mock_response
-                    mock_client.__aenter__.return_value = mock_client
-                    mock_client_class.return_value = mock_client
+                mock_client = AsyncMock()
+                mock_client.post.return_value = mock_response
+                mock_client.__aenter__.return_value = mock_client
+                mock_client_class.return_value = mock_client
 
-                    result = await client._refresh_access_token()
+                result = await client._refresh_access_token()
 
-                    assert result is True
-                    # Check that token was updated in the store
-                    assert (
-                        client.token_store.get_current().access_token
-                        == "new_access_token"
-                    )
+                assert result is True
+                # Check that token was updated in the store
+                assert (
+                    client.token_store.get_current().access_token == "new_access_token"
+                )
 
     @pytest.mark.asyncio
     async def test_refresh_access_token_no_refresh_token(
-        self, wahoo_config, monkeypatch
+        self, wahoo_config, monkeypatch, tmp_path
     ):
         # Create a token file without refresh token
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            token_data = {
-                "access_token": "test_token",
-                "expires_at": time.time() + 7200,
-                "token_type": "Bearer",
-            }
-            json.dump(token_data, f)
-            temp_path = f.name
+        token_file = tmp_path / "no_refresh_token.json"
+        token_data = {
+            "access_token": "test_token",
+            "expires_at": time.time() + 7200,
+            "token_type": "Bearer",
+        }
+        token_file.write_text(json.dumps(token_data))
 
-        try:
-            monkeypatch.setenv("WAHOO_TOKEN_FILE", temp_path)
-            async with WahooAPIClient(wahoo_config) as client:
-                result = await client._refresh_access_token()
-                assert result is False
-        finally:
-            os.unlink(temp_path)
+        monkeypatch.setenv("WAHOO_TOKEN_FILE", str(token_file))
+        async with WahooAPIClient(wahoo_config) as client:
+            result = await client._refresh_access_token()
+            assert result is False
 
     @pytest.mark.asyncio
-    async def test_call_tool_with_token_store(self, mock_workouts_response):
-        with patch.dict("os.environ", {"WAHOO_TOKEN_FILE": "/tmp/tokens.json"}):
-            mock_token_data = TokenData(
-                access_token="stored_token",
-                refresh_token="stored_refresh",
-                expires_at=time.time() + 3600,
-            )
+    async def test_call_tool_with_token_store(
+        self, mock_workouts_response, monkeypatch
+    ):
+        monkeypatch.setenv("WAHOO_TOKEN_FILE", "/tmp/tokens.json")
+        mock_token_data = TokenData(
+            access_token="stored_token",
+            refresh_token="stored_refresh",
+            expires_at=time.time() + 3600,
+        )
 
-            with patch("src.server.TokenStore") as mock_store_class:
-                mock_store = MagicMock()
-                mock_store.load.return_value = mock_token_data
-                mock_store_class.return_value = mock_store
+        with patch("src.server.TokenStore") as mock_store_class:
+            mock_store = MagicMock()
+            mock_store.load.return_value = mock_token_data
+            mock_store_class.return_value = mock_store
 
-                with patch(
-                    "src.server.WahooAPIClient.list_workouts", new_callable=AsyncMock
-                ) as mock_list:
-                    # Convert mock data to Workout objects
-                    from src.models import Workout
+            with patch(
+                "src.server.WahooAPIClient.list_workouts", new_callable=AsyncMock
+            ) as mock_list:
+                # Convert mock data to Workout objects
+                workout_objects = [
+                    Workout(**w) for w in mock_workouts_response["workouts"]
+                ]
+                mock_list.return_value = workout_objects
 
-                    workout_objects = [
-                        Workout(**w) for w in mock_workouts_response["workouts"]
-                    ]
-                    mock_list.return_value = workout_objects
+                result = await call_tool("list_workouts", {})
 
-                    from src.server import call_tool
+                assert len(result) == 1
+                assert "Found 2 workouts" in result[0].text
 
-                    result = await call_tool("list_workouts", {})
 
-                    assert len(result) == 1
-                    assert "Found 2 workouts" in result[0].text
+class TestIntensityTypeMapping:
+    """Test intensity type mapping for Wahoo API compatibility."""
+
+    def test_intensity_type_mapping(self):
+        """Test that interval types are correctly mapped to Wahoo intensity types."""
+        # Create test workout plan
+        plan = WorkoutPlan(
+            name="Test Plan",
+            intervals=[
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="power", target_value=200)],
+                    interval_type="work",  # Should map to "active"
+                ),
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="power", target_value=100)],
+                    interval_type="warmup",  # Should map to "wu"
+                ),
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="power", target_value=150)],
+                    interval_type="cooldown",  # Should map to "cd"
+                ),
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="power", target_value=120)],
+                    interval_type="rest",  # Should stay "rest"
+                ),
+            ],
+        )
+
+        # Convert to Wahoo format
+        wahoo_plan = plan.to_wahoo_format()
+
+        # Verify intensity types are correctly mapped
+        intervals = wahoo_plan["intervals"]
+        assert len(intervals) == 4
+
+        assert intervals[0]["intensity_type"] == "active"  # work -> active
+        assert intervals[1]["intensity_type"] == "wu"  # warmup -> wu
+        assert intervals[2]["intensity_type"] == "cd"  # cooldown -> cd
+        assert intervals[3]["intensity_type"] == "rest"  # rest -> rest
+
+    def test_intensity_type_case_insensitive(self):
+        """Test that intensity type mapping is case insensitive."""
+        plan = WorkoutPlan(
+            name="Test Plan",
+            intervals=[
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="power", target_value=200)],
+                    interval_type="WORK",  # Should map to "active"
+                ),
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="power", target_value=100)],
+                    interval_type="WarmUp",  # Should map to "wu"
+                ),
+            ],
+        )
+
+        wahoo_plan = plan.to_wahoo_format()
+        intervals = wahoo_plan["intervals"]
+
+        assert intervals[0]["intensity_type"] == "active"
+        assert intervals[1]["intensity_type"] == "wu"
+
+    def test_unknown_intensity_type_defaults_to_active(self):
+        """Test that unknown intensity types default to 'active'."""
+        plan = WorkoutPlan(
+            name="Test Plan",
+            intervals=[
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="power", target_value=200)],
+                    interval_type="unknown_type",  # Should default to "active"
+                ),
+            ],
+        )
+
+        wahoo_plan = plan.to_wahoo_format()
+        intervals = wahoo_plan["intervals"]
+
+        assert intervals[0]["intensity_type"] == "active"
+
+    def test_target_type_mapping(self):
+        """Test that target types are correctly mapped to Wahoo target types."""
+        plan = WorkoutPlan(
+            name="Test Plan",
+            intervals=[
+                WorkoutInterval(
+                    duration=300,
+                    targets=[
+                        WorkoutTarget(
+                            target_type="power", target_value=200
+                        ),  # Should map to "watts"
+                        WorkoutTarget(
+                            target_type="heart_rate", target_value=150
+                        ),  # Should map to "hr"
+                        WorkoutTarget(
+                            target_type="cadence", target_value=90
+                        ),  # Should map to "rpm"
+                    ],
+                    interval_type="work",
+                ),
+            ],
+        )
+
+        wahoo_plan = plan.to_wahoo_format()
+        targets = wahoo_plan["intervals"][0]["targets"]
+
+        assert len(targets) == 3
+        assert targets[0]["type"] == "watts"  # power -> watts
+        assert targets[1]["type"] == "hr"  # heart_rate -> hr
+        assert targets[2]["type"] == "rpm"  # cadence -> rpm
+
+    def test_target_type_case_insensitive(self):
+        """Test that target type mapping is case insensitive."""
+        plan = WorkoutPlan(
+            name="Test Plan",
+            intervals=[
+                WorkoutInterval(
+                    duration=300,
+                    targets=[WorkoutTarget(target_type="POWER", target_value=200)],
+                    interval_type="work",
+                ),
+            ],
+        )
+
+        wahoo_plan = plan.to_wahoo_format()
+        targets = wahoo_plan["intervals"][0]["targets"]
+
+        assert targets[0]["type"] == "watts"
+
+    def test_unknown_target_type_defaults_to_watts(self):
+        """Test that unknown target types default to 'watts'."""
+        plan = WorkoutPlan(
+            name="Test Plan",
+            intervals=[
+                WorkoutInterval(
+                    duration=300,
+                    targets=[
+                        WorkoutTarget(target_type="unknown_type", target_value=200)
+                    ],
+                    interval_type="work",
+                ),
+            ],
+        )
+
+        wahoo_plan = plan.to_wahoo_format()
+        targets = wahoo_plan["intervals"][0]["targets"]
+
+        assert targets[0]["type"] == "watts"

--- a/uv.lock
+++ b/uv.lock
@@ -128,6 +128,27 @@ wheels = [
 ]
 
 [[package]]
+name = "complexipy"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/d7/53b63787523a86f4b68f9fd7c2b017e0efae882c8807896ad7f73d01cd28/complexipy-3.2.0.tar.gz", hash = "sha256:4c80d22120ece7825f7a227dae465bb17b735a1cc9d26f387153dc299513fdd3", size = 271009, upload-time = "2025-07-09T05:34:33.239Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/4f/942b7faf179d573f5c500d340568b0086be7ff842249568def54bac57d8b/complexipy-3.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ba2b2ca283efd2631d7eaaee765139b5191a38f2f6cbb70947cfab78f323fd53", size = 2051784, upload-time = "2025-07-09T05:33:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d5/f209f484deee780bc87e0cb87ce6b39d0e5347319d21e8260bd36b29995e/complexipy-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1d52904cae62fb867839cdfc1ec0558759ba7ebdafad7d97eec9e0476b9c671", size = 1976602, upload-time = "2025-07-09T05:33:34.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/78/2b2d1ddb24751f08e99b41ca1af2defe2bf693d1b9e61f8bed8704bd76d5/complexipy-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f63a0b08019b0a48031b76c717e85728dae9f5fa8e68f81c3508f12edf44bb5", size = 2151662, upload-time = "2025-07-09T05:33:35.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3e/ea3f91bb2b7f753ef7b6b4a1d909e238b51bae4f0f614c18545d98b2126e/complexipy-3.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b75494519c6788595ab9754ca388b29321bc2395d66c92ec470af71de40feab", size = 2104305, upload-time = "2025-07-09T05:33:36.846Z" },
+    { url = "https://files.pythonhosted.org/packages/25/38/3a9865f2ab1b9e70917b8dc1490b07febb0dac37f0e1da5420bd6f0b649b/complexipy-3.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c932e3373a8a5e2ed129bf77311a2647e2c70ef56ffca2af47e863c30b5add4c", size = 2272428, upload-time = "2025-07-09T05:33:38.127Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/61/ebd26b830f4d1d6309b1513290dc1c0eb62f4369821ffeeb557c95fea927/complexipy-3.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5ee026e50d7afa188f13be32df181f14c30c57dd37706651b7a3f95eea449f2a", size = 2503571, upload-time = "2025-07-09T05:33:39.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fd/a21acd85376a22b2f8346dab2addcf8d761854f31406e21b7bb2a29dd0d0/complexipy-3.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fa327108c5737981012270638dfd6e5baa03cd0d9f3e578a0c336170d96bec81", size = 2308970, upload-time = "2025-07-09T05:33:40.719Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e9/803bc0bd05995c38c6ed650070819340dbec4a89256f314c5dc0861eb1ec/complexipy-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04cf0951c8fe91547f869c78b6dd803c3e8d1c590f864868c1b6501a3fa3fd59", size = 2224710, upload-time = "2025-07-09T05:33:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d5/162182e5801f43b668106663ebf543af4560b73e492db37ffeb669dd9784/complexipy-3.2.0-cp313-cp313-win32.whl", hash = "sha256:60f261ca9646b3a97af4f6f3d5c9d1b9040537cfce435ff31f301fd66a8c6e55", size = 1740083, upload-time = "2025-07-09T05:33:43.587Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/40/faf80989e09efa8c395cb0c0591f48b6fa20b1797d640ee65dcc3c367918/complexipy-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:8940fe67550c6b0622dc2d1c1957949a108a5896dd31520cf8c98e335fa05f00", size = 1872685, upload-time = "2025-07-09T05:33:44.796Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -320,6 +341,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -338,6 +371,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/68/63045305f29ff680a9cd5be360c755270109e6b76f696ea6824547ddbc30/mcp-1.10.1.tar.gz", hash = "sha256:aaa0957d8307feeff180da2d9d359f2b801f35c0c67f1882136239055ef034c2", size = 392969, upload-time = "2025-06-27T12:03:08.982Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/3f/435a5b3d10ae242a9d6c2b33175551173c3c61fe637dc893be05c4ed0aaf/mcp-1.10.1-py3-none-any.whl", hash = "sha256:4d08301aefe906dce0fa482289db55ce1db831e3e67212e65b5e23ad8454b3c5", size = 150878, upload-time = "2025-06-27T12:03:07.328Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -660,6 +702,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -722,6 +777,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -752,6 +816,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0a/69/662169fdb92fb96ec3eaee218cf540a629d629c86d7993d9651226a6789b/starlette-0.47.1.tar.gz", hash = "sha256:aef012dd2b6be325ffa16698f9dc533614fb1cebd593a906b90dc1025529a79b", size = 2583072, upload-time = "2025-06-21T04:03:17.337Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/95/38ef0cd7fa11eaba6a99b3c4f5ac948d8bc6ff199aabd327a29cc000840c/starlette-0.47.1-py3-none-any.whl", hash = "sha256:5e11c9f5c7c3f24959edbf2dffdc01bba860228acf657129467d8a7468591527", size = 72747, upload-time = "2025-06-21T04:03:15.705Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
 ]
 
 [[package]]
@@ -824,6 +903,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "complexipy" },
     { name = "pre-commit" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
@@ -846,6 +926,7 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "complexipy", specifier = ">=3.2.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -600,6 +600,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-watcher"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/72/a2a1e81f1b272ddd9a1848af4959c87c39aa95c0bbfb3007cacb86c47fa9/pytest_watcher-0.4.3.tar.gz", hash = "sha256:0cb0e4661648c8c0ff2b2d25efa5a8e421784b9e4c60fcecbf9b7c30b2d731b3", size = 10386, upload-time = "2024-08-28T17:37:46.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/3a/c44a76c6bb5e9e896d9707fb1c704a31a0136950dec9514373ced0684d56/pytest_watcher-0.4.3-py3-none-any.whl", hash = "sha256:d59b1e1396f33a65ea4949b713d6884637755d641646960056a90b267c3460f9", size = 11852, upload-time = "2024-08-28T17:37:45.731Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -813,6 +825,9 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-httpx" },
+    { name = "pytest-watcher" },
 ]
 
 [package.metadata]
@@ -830,7 +845,33 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pre-commit", specifier = ">=4.2.0" }]
+dev = [
+    { name = "pre-commit", specifier = ">=4.2.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "pytest-httpx", specifier = ">=0.35.0" },
+    { name = "pytest-watcher", specifier = ">=0.4.3" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
 
 [[package]]
 name = "yarl"


### PR DESCRIPTION
- Add `create_plan` tool to the API and tool registry, enabling creation of new workout plans in the user's Wahoo library.
- Implement `create_plan` method in `WahooAPIClient` to handle plan conversion, base64 encoding, and POST to `/v1/plans`.
- Add Pydantic models for workout plan creation and conversion to Wahoo API format, including `WorkoutPlan`, `WorkoutInterval`, and `WorkoutTarget`.
- Add JSON schemas for all endpoints, including `create_plan`, to `src/schemas/`.
- Refactor tool handlers for modularity and testability.
- Update tests to cover plan creation and schema validation.
- Improve error handling and code comments for clarity.