### PR TITLE
docs: document create_plan functionality in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
       if: always()
 
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
     needs: [test]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+junit.xml
 token.json
 # Python
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 	uv run pytest -v
 
 test-cov:
-	uv run pytest -v --cov=src --cov-report=xml --cov-report=term
+	uv run pytest -vvv --cov=src --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
 
 lint:
 	uv run ruff check .

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Model Context Protocol (MCP) server for interacting with the Wahoo Cloud API, 
 
 - **Workouts**: List workouts with pagination and date filtering, get detailed workout information
 - **Routes**: List and retrieve saved cycling/running routes
-- **Training Plans**: Access training plans from your Wahoo account
+- **Training Plans**: Access and create training plans in your Wahoo account
 - **Power Zones**: View power zone configurations for different workout types
 - **OAuth 2.0 Authentication**: Secure authentication with automatic token refresh
 - **Comprehensive workout type support**: 72 different workout types with location and family categorization
@@ -266,6 +266,31 @@ Example:
 Use the get_power_zone tool to get details for power zone ID 321
 ```
 
+#### create_plan
+Create a new training plan in your Wahoo account.
+
+Parameters:
+- `plan` (required): Complete workout plan structure containing:
+  - `name` (required): Name of the workout plan
+  - `description` (optional): Description of the workout
+  - `intervals` (required): List of workout intervals, each containing:
+    - `duration` (required): Duration in seconds
+    - `targets` (required): List of targets (power, heart_rate, speed, pace, rpe, cadence)
+    - `name` (optional): Name/description of the interval
+    - `interval_type` (optional): Type (work, rest, warmup, cooldown, tempo, threshold, recovery, active, or Wahoo types: wu, cd, lt, map, ac, nm, ftp, recover)
+  - `workout_type` (optional): Type of workout (bike, run, swim) - defaults to "bike"
+  - `estimated_duration` (optional): Estimated total duration in seconds
+  - `estimated_tss` (optional): Estimated Training Stress Score
+  - `author` (optional): Author of the plan
+- `external_id` (required): Unique external ID for the plan
+- `provider_updated_at` (required): External date/time the file was updated (ISO 8601 format)
+- `filename` (optional): Name of the plan file
+
+Example:
+```
+Use the create_plan tool to create a new training plan with intervals for power and heart rate zones
+```
+
 ## Development
 
 ### Running Tests
@@ -312,6 +337,7 @@ The server implements the following Wahoo Cloud API endpoints:
 **Training Plans:**
 - `GET /v1/plans` - List training plans
 - `GET /v1/plans/{id}` - Get plan details
+- `POST /v1/plans` - Create a new training plan
 
 **Power Zones:**
 - `GET /v1/power_zones` - List power zone configurations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "complexipy>=3.2.0",
   "pre-commit>=4.2.0",
   "pytest-asyncio>=1.0.0",
+  "pytest-cov>=6.2.1",
   "pytest-httpx>=0.35.0",
   "pytest-watcher>=0.4.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -906,6 +906,7 @@ dev = [
     { name = "complexipy" },
     { name = "pre-commit" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-httpx" },
     { name = "pytest-watcher" },
 ]
@@ -929,6 +930,7 @@ dev = [
     { name = "complexipy", specifier = ">=3.2.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-watcher", specifier = ">=0.4.3" },
 ]


### PR DESCRIPTION
Add comprehensive documentation for the new create_plan tool including:
- Updated features section to mention plan creation capability
- Complete tool documentation with parameters and examples
- API reference update with POST /v1/plans endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)